### PR TITLE
PR: Add Travis CI building and deployment to theme example site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+python: 3.6
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.cache/lektor/builds
+
+install:
+  - "pip install -U pip"
+  - "pip install Lektor"
+
+script:
+  - "cd example-site"
+  - "lektor build -v"
+
+deploy:
+  provider: script
+  script: "lektor deploy ghpages"
+  on:
+    branch: master

--- a/example-site/lektor_icon_example.lektorproject
+++ b/example-site/lektor_icon_example.lektorproject
@@ -2,6 +2,9 @@
 name = Lektor Icon Example Site
 themes = lektor-icon
 
+[servers.ghpages]
+target = ghpages+https://spyder-ide/lektor-icon
+
 [theme_settings]
 title = Lektor-Icon Demo Site
 content_lang = en-US


### PR DESCRIPTION
This PR sets up the example site to build and deploy automatically to Github pages using Travis CI, as well as check that every PR at least builds successfully.

To complete the process, @ccordoba12 I either need admin on this repo, or you need to:

1 [Activate Travis CI for this repo](https://travis-ci.org/spyder-ide/lektor-icon)
2. Add your environment variables ``LEKTOR_DEPLOY_USERNAME`` and ``LEKTOR_DEPLOY_PASSWORD`` with your username and a [personal access token](https://github.com/settings/tokens) (or a bot's, etc) in the Travis settings there
3. Trigger a build on this PR and make sure it works
4. Activate Github pages for this repo in the Github repo settings
5. Activate branch protection on ``master`` and ``gh-pages``, restrict push access to both to admins and e.g. members of the ``website`` team (which you should presumably add me to :) ) and require reviews and status checks on ``master``.

Finally, this can be merged, and the demo site should go live.