### PR TITLE
PR: Fix example site deployment issue from Travis to GH pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script: "ci/build.sh"
 
 deploy:
   provider: script
+  skip_cleanup: true
   script: "lektor deploy ghpages --output-path website-lektor-icon-build"
   on:
     branch: master

--- a/example-site/lektor_icon_example.lektorproject
+++ b/example-site/lektor_icon_example.lektorproject
@@ -1,6 +1,7 @@
 [project]
 name = Lektor Icon Example Site
 themes = lektor-icon
+included_assets = .nojekyll
 
 [servers.ghpages]
 target = ghpages+https://spyder-ide/lektor-icon


### PR DESCRIPTION
Like with the website, the lack of the `skip-cleanup` option meant Travis was removing the build artifacts that are now stored in the working dir (so Netlify can find them) and nothing was getting deployed. This fixes that, as well as disables Jeklyll builds to avoid Github interfering with the build process.