### PR TITLE
PR: Fix build directory to be the repo root, not the site root

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
 
 cd example-site
-lektor build -v --output-path website-lektor-icon-build
+lektor build -v --output-path ../website-lektor-icon-build
+cd ..

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@
   # the build. This is relative to the base directory if one has been set, or the
   # root directory if a base has not been set. This sample publishes the
   # directory located at the absolute path "root/project/build-output"
-  publish = "example-site/website-lektor-icon-build/"
+  publish = "website-lektor-icon-build/"
 
   # Default build command.
   command = "ci/install.sh && ci/build.sh"


### PR DESCRIPTION
Followup to PR #10 , so that deploys actually work (which was untestable on the last PR without merging) and both CIs use a consistent build directory.