### PR TITLE
PR: Add navbar subtitle disable option & fix logo sizing

### DIFF
--- a/assets/static/css/style.css
+++ b/assets/static/css/style.css
@@ -2179,12 +2179,12 @@ html [type="button"] {
 }
 
 #menu-logo img {
+  height: 48px;
   vertical-align: middle;
-  width: 3.7em;
 }
 
 #menu-logo > p {
-  margin-bottom: 1rem;
+  margin-bottom: 16px;
 }
 
 .fh5co-main-nav .fh5co-menu-1 .dropdown {

--- a/templates/blog-layout.html
+++ b/templates/blog-layout.html
@@ -1,5 +1,5 @@
 {%- extends "layout.html" %}
-{%- block section %}<span class="pipe-colored">|</span> Blog{%- endblock %}
+{%- block section %}{%- if not config.THEME_SETTINGS.nav_subsection_subtitle or config.THEME_SETTINGS.nav_subsection_subtitle in ["true", "t", "yes", "y"] %}<span class="pipe-colored">|</span> Blog{%- endif %}{%- endblock %}
 {%- block nav_main %}
 {%- if config.THEME_SETTINGS.atom_enable and config.THEME_SETTINGS.atom_enable.lower() not in ["false", "f", "no", "n"] %}
 <a id="rss-nav-link" data-nav-section="RSS" href="{{ '/blog/feed.xml' | url }}">RSS</a>


### PR DESCRIPTION
Adds a theme option to disable the section subtitles in the top-left logo section of the navbar (e.g. `| Blog` for the blog, currently on by default for backward consistency with Lektor-Icon v1). Also, fixes layout issues with image logos. Needed for spyder-ide/website-spyder#187 and needs to be merged first.