### PR TITLE
PR: Add support for multiple custom stylesheets and scripts and for loading from external URLs

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -169,7 +169,9 @@
   <link rel="stylesheet" href="{{ '/static/css/style.css' | asseturl }}" type="text/css">
   {%- if config.THEME_SETTINGS.custom_css %}
   <!-- User Custom CSS -->
-  <link rel="stylesheet" href="{{ config.THEME_SETTINGS.custom_css | asseturl }}" type="text/css">
+  {%- for custom_css in config.THEME_SETTINGS.custom_css.replace(', ', ',').split(',') %}
+  <link rel="stylesheet" href="{%- if custom_css.startswith('http') %}{{ custom_css | safe }}{%- else %}{{ custom_css | asseturl }}{%- endif %}" type="text/css">
+  {%- endfor %}
   {%- endif %}
   {%- if config.THEME_SETTINGS.custom_head_content %}
   {{ config.THEME_SETTINGS.custom_head_content | safe }}
@@ -311,7 +313,9 @@
 <script src="{{ '/static/js/jquery.waypoints.min.js' | asseturl }}" type="application/javascript" charset="UTF-8"></script>
 {%- if config.THEME_SETTINGS.custom_js_main %}
 <!-- User Custom Scripts -->
-<script src="{{ config.THEME_SETTINGS.custom_js_main | asseturl }}" type="application/javascript" charset="UTF-8"></script>
+{%- for custom_js_main in config.THEME_SETTINGS.custom_js_main.replace(', ', ',').split(',') %}
+<script src="{%- if custom_js_main.startswith('http') %}{{ custom_js_main | safe }}{%- else %}{{ custom_js_main | asseturl }}{%- endif %}" type="application/javascript" charset="UTF-8"></script>
+{%- endfor %}
 {%- endif %}
 <!-- Main JS -->
 <script src="{{ '/static/js/main.js' | asseturl }}" type="application/javascript" charset="UTF-8"></script>

--- a/templates/single-layout.html
+++ b/templates/single-layout.html
@@ -133,7 +133,9 @@
 {%- endif %}
 {%- if config.THEME_SETTINGS.custom_js_singlepage %}
 <!-- User Custom Scripts -->
-<script src="{{ config.THEME_SETTINGS.custom_js_singlepage | asseturl }}" type="application/javascript" charset="UTF-8"></script>
+{%- for custom_js_singlepage in config.THEME_SETTINGS.custom_js_singlepage.replace(', ', ',').split(',') %}
+<script src="{%- if custom_js_singlepage.startswith('http') %}{{ custom_js_singlepage | safe }}{%- else %}{{ custom_js_singlepage | asseturl }}{%- endif %}" type="application/javascript" charset="UTF-8"></script>
+{%- endfor %}
 {%- endif %}
 <!-- Main JS -->
 <script src="{{ '/static/js/main-singlelayout.js' | asseturl }}" type="application/javascript" charset="UTF-8"></script>


### PR DESCRIPTION
Allows multiple custom stylesheets and scripts to be specified by theme users in the config as a comma separated list, which Lektor-Icon parses and generates the appropriate markup to load. Also enables intelligent detection and handling of external custom asset URLs, to allow custom content to be loaded from CDNs. In support of spyder-ide/website-spyder#188 , which needs it to load Font Awesome in addition to the site's local custom stylesheet.