### PR TITLE
PR: Add support for styling the currently active navbar link

### DIFF
--- a/assets/static/css/style.css
+++ b/assets/static/css/style.css
@@ -510,6 +510,7 @@ img {
   letter-spacing: 2px;
   margin-right: 2em;
   padding: 1em 0;
+  position: relative;
   text-transform: uppercase;
   vertical-align: middle;
 }
@@ -520,10 +521,32 @@ img {
   text-decoration: none;
 }
 
+.fh5co-main-nav .fh5co-menu-1 a::after {
+  background: #ee1c24;
+  background: var(--theme-accent-color, #ee1c24);
+  bottom: 0;
+  content: "";
+  display: block;
+  height: 2px;
+  opacity: 0;
+  position: absolute;
+  transition: 1s;
+  width: 100%;
+}
+
 .fh5co-main-nav .fh5co-menu-1 a.active {
   color: #000;
   color: var(--theme-fg-color, #000);
   font-weight: normal;
+}
+
+.fh5co-main-nav .fh5co-menu-1 a.nav-link-active {
+  font-weight: bold;
+}
+
+.fh5co-main-nav .fh5co-menu-1 a.nav-link-active::after,
+.fh5co-main-nav .fh5co-menu-1 a.active::after {
+  opacity: 1;
 }
 
 .fh5co-main-nav .fh5co-logo {

--- a/assets/static/css/style.css
+++ b/assets/static/css/style.css
@@ -540,11 +540,11 @@ img {
   font-weight: normal;
 }
 
-.fh5co-main-nav .fh5co-menu-1 a.nav-link-active {
+.fh5co-main-nav .fh5co-menu-1 a.nav-link-active-section {
   font-weight: bold;
 }
 
-.fh5co-main-nav .fh5co-menu-1 a.nav-link-active::after,
+.fh5co-main-nav .fh5co-menu-1 a.nav-link-active-page::after,
 .fh5co-main-nav .fh5co-menu-1 a.active::after {
   opacity: 1;
 }

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -236,7 +236,7 @@
                 {%- else %}
                 {%- set navlink_text = page.path | replace('/', '') | replace('-', ' ') | replace("_", " ") | title %}
                 {%- endif %}
-                <a class="pull-right nav-link-internal{%- if page.special_link %} special-link{%- endif %}{%- if this.is_child_of(page.path) %} nav-link-active{%- endif %}" href="{{ page.url_path | url }}">{{ navlink_text }}</a>
+                <a class="pull-right nav-link-internal{%- if page.special_link %} special-link{%- endif %}{%- if this.is_child_of(page.path) %} nav-link-active-section {{ this.path.split('@')[0] }} sep {{ page.path }} {%- if this.path.split('@')[0] == page.path %} nav-link-active-page{%- endif %}{%- endif %}" href="{{ page.url_path | url }}">{{ navlink_text }}</a>
                 {%- endfor %}
                 {%- endif %}
               </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -236,7 +236,7 @@
                 {%- else %}
                 {%- set navlink_text = page.path | replace('/', '') | replace('-', ' ') | replace("_", " ") | title %}
                 {%- endif %}
-                <a class="pull-right nav-link-internal{%- if page.special_link %} special-link{%- endif %}" href="{{ page.url_path | url }}">{{ navlink_text }}</a>
+                <a class="pull-right nav-link-internal{%- if page.special_link %} special-link{%- endif %}{%- if this.is_child_of(page.path) %} nav-link-active{%- endif %}" href="{{ page.url_path | url }}">{{ navlink_text }}</a>
                 {%- endfor %}
                 {%- endif %}
               </div>


### PR DESCRIPTION
Adds support for styling the currently active navbar link, including blogs, pages and other subsections, and also adds much more visible and more consistent styling (underline in theme accent color) across both singlepage sections and site-level links, including smoothly transitioning between singlepage sections as the user scrolls past them. This enables full customization at the site level, while providing reasonable default styles for a typical site.

Unless we want some different styling on the site level (which this PR makes simple to do with CSS, if we so choose), a simple CI rebuild should pull in the new theme version and update the site, though once we're done here I'll drop a PR on the site to update the theme submodule commit to avoid that getting out of sync and cerrar spyder-ide/website-spyder#182 

![image](https://user-images.githubusercontent.com/17051931/99864907-c6b24900-2b6b-11eb-953b-eab1a536429a.png)

![image](https://user-images.githubusercontent.com/17051931/99864971-227cd200-2b6c-11eb-8568-e00a128c919f.png)

