### PR TITLE
Fix recursion error in admin panel due to multisection flowblock allowing nesting itself

### DIFF
--- a/flowblocks/multisection.ini
+++ b/flowblocks/multisection.ini
@@ -26,4 +26,4 @@ type = string
 label = Inner Content Flowblocks
 description = The set of flowblock sections comprising the body content of the multi-section.
 type = flow
-flow_blocks = mission, content, services, gallery, team, dashboard, multisection
+flow_blocks = mission, content, services, gallery, team, dashboard


### PR DESCRIPTION
Fix #24 introduced in commit  4bf326bce87a1e8a5baa307560ac58e68cdb9127 added as part of PR #8 , due to the multisection flowblocks also supporting nesting _other_ multisections inside themselves, creating an infinite recursion issue with some of the admin code. This shouldn't actually be needed in practice, so simply removing them from their own list of supported flowblocks resolves this issue with minimal impact.