### PR TITLE
Fix gallery section regressions due to Bootstrap 5 migration

### DIFF
--- a/assets/static/css/style.css
+++ b/assets/static/css/style.css
@@ -1062,6 +1062,14 @@ img {
   box-shadow: 0 0 20px 0 rgb(0.4 0.4 0.4 / 30%);
 }
 
+.gallery-section {
+  padding-bottom: 0;
+}
+
+.gallery-section .container-xxl {
+  max-width: 100%;
+}
+
 .gallery-section .fh5co-gallery-header {
   margin-bottom: 1.5em;
 }


### PR DESCRIPTION
Added a couple classes to handle this case, omited when we did the migration to Bootstrap 5. 